### PR TITLE
use target latency in service description for initial playhead position

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2494,6 +2494,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   createPlayhead(startTime) {
     goog.asserts.assert(this.manifest_, 'Must have manifest');
     goog.asserts.assert(this.video_, 'Must have video');
+    if (!startTime && this.getServiceDescription()) {
+      if (this.getServiceDescription().latency) {
+        startTime = -this.getServiceDescription().latency.target / 1000;
+      }
+    }
     return new shaka.media.MediaSourcePlayhead(
         this.video_,
         this.manifest_,


### PR DESCRIPTION
Use target latency in service description to fix long start time in HMS-5920
